### PR TITLE
Dependency Installation File Missing Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ After searching on YouTube and following the recommendations, it prints the 50 m
 To install the project's python dependencies, you can use pip:
 
 ```
-pip install -r requirements
+pip install -r requirements.txt
 ```
 
 Used dependencies:


### PR DESCRIPTION
Requirements is missing .txt extension:

```
❯ pip install -r requirements
Could not open requirements file: [Errno 2] No such file or directory: 'requirements'
```

Tested on both raspian and mac osx sierra.