### PR TITLE
Add link to youtube-explore-to-gexf to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ python2.7 follow-youtube-recommendations.py  --query="global warming,vaccines,na
 * --branch: branching factor = number of recommendations that are followed
 * --name: name under which it will be saved
 * --alltime: add this option if you want to start from the most viewed videos for the query (using the option filter by viewcount on youtube)
+
+#### Related projects
++ Convert JSON outputs to .gexf with [youtube-explore-to-gexf](https://github.com/ejfox/youtube-explore-to-gexf)


### PR DESCRIPTION
I created an extremely simple [node script](https://www.npmjs.com/package/youtube-explore-to-gexf) that converts the JSON outputs created here to the `.gexf` file format which is easily imported into Gephi.

Would it be possible to add a link to the bottom of the README so that others can easily find this tool if they need it? 